### PR TITLE
Removed WorldObject

### DIFF
--- a/src/main/java/us/timinc/jsonifycraft/description/BlockDescription.java
+++ b/src/main/java/us/timinc/jsonifycraft/description/BlockDescription.java
@@ -12,7 +12,7 @@ import us.timinc.jsonifycraft.world.JsonedBlockItem;
 import java.util.ArrayList;
 import java.util.List;
 
-public class BlockDescription extends WorldObjectDescription implements IProviderBlock, IProviderItem {
+public class BlockDescription extends ItemDescription implements IProviderBlock, IProviderItem {
     public String material = "ground";
     public String sounds = "stone";
     public String mapcolor = "";

--- a/src/main/java/us/timinc/jsonifycraft/description/ItemDescription.java
+++ b/src/main/java/us/timinc/jsonifycraft/description/ItemDescription.java
@@ -8,7 +8,11 @@ import us.timinc.jsonifycraft.world.JsonedItem;
 import java.util.ArrayList;
 import java.util.List;
 
-public class ItemDescription extends WorldObjectDescription implements IProviderItem {
+public class ItemDescription extends JsonDescription implements IProviderItem {
+    public String group = "misc";
+    public String rarity = "common";
+    public int stack = 64;
+
     @Override
     public List<Item> getItems() {
         ArrayList<Item> items = new ArrayList<>();

--- a/src/main/java/us/timinc/jsonifycraft/description/JsonDescription.java
+++ b/src/main/java/us/timinc/jsonifycraft/description/JsonDescription.java
@@ -3,6 +3,7 @@ package us.timinc.jsonifycraft.description;
 import java.util.Arrays;
 
 public class JsonDescription {
+    public String name;
     public String type;
     public String[] flags = {};
 

--- a/src/main/java/us/timinc/jsonifycraft/description/WorldObjectDescription.java
+++ b/src/main/java/us/timinc/jsonifycraft/description/WorldObjectDescription.java
@@ -1,8 +1,0 @@
-package us.timinc.jsonifycraft.description;
-
-public class WorldObjectDescription extends JsonDescription {
-    public String name;
-    public String group = "misc";
-    public String rarity = "common";
-    public int stack = 64;
-}

--- a/src/main/java/us/timinc/jsonifycraft/world/JsonedBlockItem.java
+++ b/src/main/java/us/timinc/jsonifycraft/world/JsonedBlockItem.java
@@ -7,11 +7,10 @@ import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import us.timinc.jsonifycraft.JsonifyCraft;
 import us.timinc.jsonifycraft.description.BlockDescription;
-import us.timinc.jsonifycraft.description.WorldObjectDescription;
 import us.timinc.mcutil.MCRegistry;
 
 public class JsonedBlockItem extends ItemBlock {
-    private WorldObjectDescription description;
+    private final BlockDescription description;
 
     private EnumRarity rarity;
 


### PR DESCRIPTION
It doesn't make sense to have Block and Item extend some arbitrary WorldObject. It makes a lot of sense for Block to extend Item, since every Block has a corresponding Item that it builds on.