### PR TITLE
Added food.nourishment

### DIFF
--- a/src/main/java/us/timinc/jsonifycraft/description/FoodDescription.java
+++ b/src/main/java/us/timinc/jsonifycraft/description/FoodDescription.java
@@ -4,14 +4,15 @@ import net.minecraft.item.Item;
 import us.timinc.jsonifycraft.JsonifyCraft;
 import us.timinc.jsonifycraft.description.tidbits.EffectDescription;
 import us.timinc.jsonifycraft.world.JsonedFood;
+import us.timinc.mcutil.MCRegistry;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class FoodDescription extends ItemDescription {
   public int hunger;
-  public float saturation;
-  public boolean meat;
+  public float saturation = -1.0F;
+  public String nourishment = "normal";
   public boolean canEatWhenFull;
   public boolean fastToEat;
   public EffectDescription[] effects = {};
@@ -23,5 +24,13 @@ public class FoodDescription extends ItemDescription {
     items.add(new JsonedFood(this).setRegistryName(name).setUnlocalizedName(JsonifyCraft.MODID + "." + name));
 
     return items;
+  }
+
+  public float getSaturation() {
+    if (saturation != -1.0F) {
+      return saturation;
+    } else {
+      return MCRegistry.NOURISHMENT_TIERS.getFromName(nourishment);
+    }
   }
 }

--- a/src/main/java/us/timinc/jsonifycraft/world/JsonedFood.java
+++ b/src/main/java/us/timinc/jsonifycraft/world/JsonedFood.java
@@ -25,7 +25,7 @@ public class JsonedFood extends ItemFood {
   private EnumRarity rarity;
 
   public JsonedFood(FoodDescription foodDescription) {
-    super(foodDescription.hunger, foodDescription.saturation, foodDescription.meat);
+    super(foodDescription.hunger, foodDescription.getSaturation(), foodDescription.hasFlag("meat"));
 
     this.description = foodDescription;
 

--- a/src/main/java/us/timinc/mcutil/MCRegistry.java
+++ b/src/main/java/us/timinc/mcutil/MCRegistry.java
@@ -177,6 +177,33 @@ public abstract class MCRegistry<T> {
         }
     }.setup();
 
+    public static MCRegistry<Float> NOURISHMENT_TIERS = new MCRegistry<Float>() {
+        private Map<String, Float> nourishment_tiers;
+
+        @Override
+        public MCRegistry<Float> setup() {
+            nourishment_tiers = new HashMap<>();
+
+            nourishment_tiers.put("SUPERNATURAL", 2.4F);
+            nourishment_tiers.put("GOOD", 1.6F);
+            nourishment_tiers.put("NORMAL", 1.2F);
+            nourishment_tiers.put("LOW", 0.6F);
+            nourishment_tiers.put("POOR", 0.2F);
+
+            return this;
+        }
+
+        @Override
+        public Float getFromName(String name) {
+            return nourishment_tiers.get(name.toUpperCase());
+        }
+
+        @Override
+        public boolean isValidName(String name) {
+            return nourishment_tiers.containsKey(name.toUpperCase());
+        }
+    }.setup();
+
     public static MCRegistry<EnumRarity> RARITIES = new MCRegistry<EnumRarity>() {
         @Override
         public MCRegistry<EnumRarity> setup() {


### PR DESCRIPTION
This is an easy alternative to food.saturation. It uses a registry that indexes the values present at https://minecraft.gamepedia.com/Food#Nourishment_value.
As a result of adding this, food.saturation logic has changed. It defaults to -1.0F, which ignores the value and uses food.nourishment instead. Setting food.saturation manually overrides food.nourishment.